### PR TITLE
feat: prefer github assignees instead of auther

### DIFF
--- a/bleach/sourcecontrol/github.py
+++ b/bleach/sourcecontrol/github.py
@@ -20,16 +20,25 @@ def listPullRequests(owner, repository):
             raise Exception("unauthorized, check your access token")
 
         pullrequests = response.json()
-        processedResults.extend(
-            pullrequest.PullRequest(
-                repo=repository,
-                createdAt=pullrequestInfo['created_at'],
-                user=pullrequestInfo['user']['login'],
-                title=pullrequestInfo['title'],
-                url=pullrequestInfo['html_url'],
+
+        def getLogin(user):
+            return user['login']
+
+        for pullrequestInfo in pullrequests:
+            if 'assignees' in pullrequestInfo and len(pullrequestInfo['assignees']):
+                user = ', '.join(map(getLogin, pullrequestInfo['assignees']))
+            else:
+                user = getLogin(pullrequestInfo['user'])
+
+            processedResults.append(
+                pullrequest.PullRequest(
+                    repo=repository,
+                    createdAt=pullrequestInfo['created_at'],
+                    user=user,
+                    title=pullrequestInfo['title'],
+                    url=pullrequestInfo['html_url'],
+                )
             )
-            for pullrequestInfo in pullrequests
-        )
 
         if response.links and 'next' in response.links:
             url = response.links['next']['url']


### PR DESCRIPTION
On GitHub, the assignee of a PR is more relevant to responsibility, and easier to change than an owner. 

This PR makes GitHub PRs display the assignee(s) where set, falling back to the owner where no assignees were set.

<img width="1440" alt="Screenshot 2019-06-06 at 12 54 59" src="https://user-images.githubusercontent.com/813784/59030973-5d952380-885a-11e9-966f-a06c49ea50e7.png">
